### PR TITLE
package.js file fixes

### DIFF
--- a/package.js
+++ b/package.js
@@ -31,7 +31,7 @@ Package.register_extension("handlebars",
     type: "js",
     data: new Buffer(data),
     where: where,
-    path: sourceDir + "test.js"
+    path: path.resolve(sourceDir, templateName + '.tmpl.js')
   });
 });
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ var fs = Npm.require('fs');
 var path = Npm.require('path');
 
 Npm.depends({
-  "handlebars": "v1.0.10"
+  "handlebars": "1.0.10"
 });
 
 Package.describe({


### PR DESCRIPTION
Thanks for great package, but I've found some small bugs in it:
1) Version number format for `handlebars` in `Npm.depends()` is wrong. Because of this meteor resolves npm-dependences every time application runs.
2) Wrong bundled script filename, so every other bundled file overwrites the previous one.
