### PR TITLE
added a basic partials support

### DIFF
--- a/plugin/compile-handlebars.js
+++ b/plugin/compile-handlebars.js
@@ -17,7 +17,8 @@ Plugin.registerSourceHandler("handlebars", function (compileStep) {
   
   js = [
     "var template = OriginalHandlebars.compile(" + JSON.stringify(contents) + ");",
-    "Handlebars.templates[" + JSON.stringify(templateName) + "] = function (data) { ",
+    "Handlebars.templates[" + JSON.stringify(templateName) + "] = function (data, partials) { ",
+    "partials = (partials || {});",
     "return template(data || {}, { ",
       "helpers: OriginalHandlebars.helpers,",
       "partials: {},",

--- a/plugin/compile-handlebars.js
+++ b/plugin/compile-handlebars.js
@@ -21,7 +21,7 @@ Plugin.registerSourceHandler("handlebars", function (compileStep) {
     "partials = (partials || {});",
     "return template(data || {}, { ",
       "helpers: OriginalHandlebars.helpers,",
-      "partials: {},",
+      "partials: partials,",
       "name: " + JSON.stringify(templateName),
      "});",
     "};"


### PR DESCRIPTION
One-line add that seems to work for my case - just added a second argument to the templates in the Handlebars.templates namespace, allows them to take an object of templates as partials, and then Handlebars works as usual

```
<!-- test.handlebars -->

<template name='test'>
    <ul>
            {{#each list}}
                <li>{{>list item}}</li>
             {{/each}}
        </ul>
</template>

<!-- listitem.handlebars -->

<template name='listitem' >
    <li>my name is {{this}}</li>
</template>

var listitem = Handlebars.templates['listitem'];
var html = Handlebars.templates['test']({ list : ['me', 'you', 'bobby sue']}, { listitem : listitem });
```

Still need to have each template in a separate file though, maybe I can dig in meteor code to see how to loosen that up
