### PR TITLE
Fixed instructions install the package locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ side rendering support.
 > git init
 > mkdir packages
 > git submodule add https://github.com/EventedMind/meteor-handlebars-server.git packages/handlebars-server
+> meteor add handlebars-server
 ```
 
 ## Usage


### PR DESCRIPTION
Meteor 0.9 apparently requires that packages get added via `meteor add handlebars-server`.
